### PR TITLE
Adds autosearch command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
+.vscode/
 .venv/
 dist/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ lrcup search never gonna give you up
 lrcup autosearch /mnt/music/
 
 # Search and embed lyrics for a given folder:
-lrcup autoembed /mnt/music/
+lrcup autosearch --embed /mnt/music/
+
+# Search and embed lyrics for a given folder, also save lrc files:
+lrcup autosearch --embed --download /mnt/music/
 ```
 
 ## Module Usage

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ lrcup embed lyrics.lrc track.flac
 # Search for lyrics and download them:
 lrcup search never gonna give you up
 
+# Search and download lyrics for a given folder:
+lrcup autosearch /mnt/music/
+
 # Search and embed lyrics for a given folder:
 lrcup autoembed /mnt/music/
 ```


### PR DESCRIPTION
Hello! This is just a feature I felt was lacking in lrcup that I needed for my own library, so I took a shot at implementing it.

It adds an `autosearch` command that does the same as `autoembed`, except it downloads the lyrics into an .lrc file of same name of the audio file in in the same directory. Some of my player applications just refuse to read lyrics embedded into the audio files, so I have the .lrc files stored in this way for them to read.

If you believe there are any changes that are needed to be done to the code before merging, I would be happy to implement those changes.